### PR TITLE
Add metadata to package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.3.0
 	github.com/kylelemons/godebug v1.1.0
+	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/omaha/package.go
+++ b/omaha/package.go
@@ -31,11 +31,12 @@ var (
 
 // Package represents a single downloadable file.
 type Package struct {
-	Name     string `xml:"name,attr"`
-	SHA1     string `xml:"hash,attr"`
-	SHA256   string `xml:"hash_sha256,attr,omitempty"`
-	Size     uint64 `xml:"size,attr"`
-	Required bool   `xml:"required,attr"`
+	Name     string    `xml:"name,attr"`
+	SHA1     string    `xml:"hash,attr"`
+	SHA256   string    `xml:"hash_sha256,attr,omitempty"`
+	Size     uint64    `xml:"size,attr"`
+	Required bool      `xml:"required,attr"`
+	Metadata *Metadata `xml:"metadata,omitempty"`
 }
 
 func (p *Package) FromPath(name string) error {
@@ -108,4 +109,18 @@ func multihash(r io.Reader) (sha1b64, sha256b64 string, n int64, err error) {
 	sha1b64 = base64.StdEncoding.EncodeToString(h1.Sum(nil))
 	sha256b64 = base64.StdEncoding.EncodeToString(h256.Sum(nil))
 	return
+}
+
+func (p *Package) AddMetadata(content string, contentType string) *Metadata {
+	mtd := &Metadata{
+		ContentType: contentType,
+		Content:     content,
+	}
+	p.Metadata = mtd
+	return mtd
+}
+
+type Metadata struct {
+	ContentType string `xml:"content-type,attr,omitempty"`
+	Content     string `xml:",cdata"`
 }

--- a/omaha/package_test.go
+++ b/omaha/package_test.go
@@ -18,7 +18,10 @@ import (
 	"strings"
 	"testing"
 
+	"encoding/xml"
+
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPackageFromPath(t *testing.T) {
@@ -141,4 +144,28 @@ func TestPackageVerifyBadSHA256(t *testing.T) {
 	if err != PackageHashMismatchError {
 		t.Error(err)
 	}
+}
+
+func TestPackageWithMetadata(t *testing.T) {
+	jsonContent := "{url: 'http://example.com'}"
+	p := Package{
+		Name:     "null",
+		SHA1:     "2jmj7l5rSw0yVb/vlWAYkK/YBwk=",
+		SHA256:   "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
+		Size:     0,
+		Required: false,
+		Metadata: &Metadata{
+			ContentType: "content/json",
+			Content:     jsonContent,
+		},
+	}
+
+	assert.Equal(t, jsonContent, p.Metadata.Content)
+
+	xmlPkg := []byte("<Package name=\"\" hash=\"\" hash_sha256=\"\" size=\"\" required=\"false\"><metadata content-type=\"content/json\"><![CDATA[" + jsonContent + "]]></metadata></Package>")
+
+	var newPkg Package
+	err := xml.Unmarshal(xmlPkg, &newPkg)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Metadata.Content, newPkg.Metadata.Content)
 }


### PR DESCRIPTION
These PR has commits from PR #6 , but I wanted to open it already on top of the new changes (so I don't have to add the new module to the vendor dir).
- Remove vendor dir
- Update semver module to v4
- Replace UUID module by google/uuid

New commit (the one to be reviewed in this PR):
- Add a new "metadata" member to package
