### PR TITLE
package: Omit empty hash attributes

### DIFF
--- a/omaha/package.go
+++ b/omaha/package.go
@@ -32,7 +32,7 @@ var (
 // Package represents a single downloadable file.
 type Package struct {
 	Name     string    `xml:"name,attr"`
-	SHA1     string    `xml:"hash,attr"`
+	SHA1     string    `xml:"hash,attr,omitempty"`
 	SHA256   string    `xml:"hash_sha256,attr,omitempty"`
 	Size     uint64    `xml:"size,attr"`
 	Required bool      `xml:"required,attr"`


### PR DESCRIPTION
The SHA1 hash attribute is mandatory but with the presence of the SHA256 attribute it doesn't make much sense to carry it around. Allow to omit the hash attribute so that SHA256 would be the used hash attribute instead.

