### PR TITLE
Update names and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 
 # Go Omaha
 
-![Go](https://github.com/kinvolk/go-omaha/workflows/Go/badge.svg)
-[![GoDoc](https://godoc.org/github.com/kinvolk/go-omaha/omaha?status.svg)](https://godoc.org/github.com/kinvolk/go-omaha/omaha)
+![Go](https://github.com/flatcar/go-omaha/workflows/Go/badge.svg)
+[![GoDoc](https://godoc.org/github.com/flatcar/go-omaha/omaha?status.svg)](https://godoc.org/github.com/flatcar/go-omaha/omaha)
 
 Implementation of the [omaha update protocol](https://github.com/google/omaha) in Go.
 
 ## Status
 
-This code is targeted for use with Kinvolk's [Nebraska](https://github.com/kinvolk/nebraska) project and the Container Linux [update_engine](https://github.com/kinvolk/update_engine).
+This code is targeted for use with Flatcar's [Nebraska](https://github.com/flatcar/nebraska) project and the Container Linux [update_engine](https://github.com/flatcar/update_engine).
 As a result this is not a complete implementation of the [protocol](https://github.com/google/omaha/blob/master/doc/ServerProtocolV3.md) and inherits a number of quirks from update_engine.
 These differences include:
 
@@ -37,7 +37,7 @@ These differences include:
 
 ## `serve-package`
 
-This project includes a very simple program designed to serve a single Container Linux package on the local host. It is intended to be used as a manual updater for a machine that is not able to use a full-fledged Nebraska instance. Binaries are available for each released version on the [releases page](https://github.com/kinvolk/go-omaha/releases). `serve-package` can also be built from source using the provided Makefile:
+This project includes a very simple program designed to serve a single Container Linux package on the local host. It is intended to be used as a manual updater for a machine that is not able to use a full-fledged Nebraska instance. Binaries are available for each released version on the [releases page](https://github.com/flatcar/go-omaha/releases). `serve-package` can also be built from source using the provided Makefile:
 
 ```bash
 make
@@ -45,7 +45,7 @@ make
 
 The binary will be available in the `bin/` folder.
 
-It is recommended that the server be run directly on the machine you intend to update. Go to the [Container Linux release notes](https://kinvolk.io/flatcar-container-linux/releases/) and find the version number for the release you would like to update to. The update payload can be retrieved from
+It is recommended that the server be run directly on the machine you intend to update. Go to the [Container Linux release notes](https://flatcar.org/releases) and find the version number for the release you would like to update to. The update payload can be retrieved from
 
 ```html
 https://update.release.flatcar-linux.net/amd64-usr/<version>/flatcar_production_update.gz
@@ -86,8 +86,8 @@ sudo systemctl reboot
 
 ### Issues
 
-Please report any issues in the [Flatcar repo](https://github.com/kinvolk/flatcar/issues).
+Please report any issues in the [flatcar/Flatcar repo](https://github.com/flatcar/Flatcar/issues).
 
 ### Code of Conduct
 
-Please refer to the [Kinvolk Code of Conduct](https://github.com/kinvolk/contribution/blob/master/CODE_OF_CONDUCT.md).
+Please refer to the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/cmd/serve-package/main.go
+++ b/cmd/serve-package/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kinvolk/go-omaha
+module github.com/flatcar/go-omaha
 
 go 1.15
 
@@ -6,5 +6,5 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.3.0
 	github.com/kylelemons/godebug v1.1.0
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/omaha/client/client.go
+++ b/omaha/client/client.go
@@ -23,7 +23,7 @@ import (
 
 	uuid "github.com/google/uuid"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 const (

--- a/omaha/client/client_test.go
+++ b/omaha/client/client_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 // implements omaha.Updater

--- a/omaha/client/error.go
+++ b/omaha/client/error.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 var (

--- a/omaha/client/example_test.go
+++ b/omaha/client/example_test.go
@@ -21,7 +21,7 @@ import (
 	//"os/signal"
 	"syscall"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 func Example() {

--- a/omaha/client/http.go
+++ b/omaha/client/http.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 const (

--- a/omaha/client/http_test.go
+++ b/omaha/client/http_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 const (

--- a/omaha/client/update_engine_events.go
+++ b/omaha/client/update_engine_events.go
@@ -18,7 +18,7 @@ package client
 import (
 	"fmt"
 
-	"github.com/kinvolk/go-omaha/omaha"
+	"github.com/flatcar/go-omaha/omaha"
 )
 
 var (
@@ -46,7 +46,7 @@ var (
 type ExitCode int
 
 // These error codes are from CoreOS Container Linux update_engine 0.4.x
-// https://github.com/kinvolk/update_engine/blob/master/src/update_engine/action_processor.h
+// https://github.com/flatcar/update_engine/blob/master/src/update_engine/action_processor.h
 // The whole list is included for the sake of completeness but lots of these
 // are not generally applicable and not even used by update_engine any more.
 // Also there are clearly duplicate errors for the same condition.


### PR DESCRIPTION
# Update "kinvolk" -> "flatcar", and point to CNCF things like Code of Conduct.

This project is in the flatcar org now, and therefore is in CNCF.

This will require updates to imports that use it, like https://github.com/flatcar/nebraska/blob/main/backend/go.mod#L18

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

`go test -v ./...`
and clicked the links in README to check for deadlinks

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
