### PR TITLE
bump actions versions to stable releases

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ^1.13
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
# Bump GH actions to stable releases

This bumps the `setup-go` and `checkout` actions used in the `go` workflow to the latest stable releases

## How to use

Create a PR against this repo and watch them succeed.

## Testing done

[Example](https://github.com/tylerauerbeck/go-omaha/actions/runs/15841110042/job/44653880454) run against my fork

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
