### PR TITLE
ci: set default branch to 'main'

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,11 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - main
   pull_request:
-    branches: [ master ]
+    branches:
+      - main
 
 jobs:
 


### PR DESCRIPTION
For some reasons (I guess because it was a fork), the default branch was set to `master` in the workflow file. Let's set it back to 'main' to enable back the CI.