### PR TITLE
add dependabot to watch for actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "monday"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
# Add dependabot config to watch for github actions updates

This PR adds a dependabot config file that tells it to look for any updates to the actions that are used within the `go` workflow on a daily basis.

## How to use

N/A. Dependabot will see the configuration for this repository and begin checking for any updates to the existing actions on a daily basis.

## Testing done

This is just following the specified instructions from GitHub [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference).

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
