### PR TITLE
bump go to v1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/flatcar/go-omaha
 
-go 1.15
+go 1.24
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/uuid v1.3.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
# Bump go to v1.24

Bumps `go.mod` to `v1.24`. Currently it's sitting at `v1.15` which was fairly out of date.

## How to use

N/A

## Testing done

`go test -v ./...`

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
