### PR TITLE
add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+version: "2"
+run:
+  issues-exit-code: 1
+  tests: true
+linters:
+  enable:
+    - revive
+    - whitespace
+    - errcheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/flatcar/go-omaha
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Add golangci-lint config

This adds an initial `golangci-lint` config (copied from Nebraska) to begin linting this repo and apply various best practices.

## How to use

`golangci-lint run -v ./...`

## Testing done

I ran this and begin fixing the various lints that were found. However, there are quite a few and some of them will likely require some changes that would impact if other upstream packages make use of them. To make these changes safely without impacting existing applications/users, I would recommend following the steps mentioned [here](https://github.com/flatcar/go-omaha/issues/17#issuecomment-3006750276).

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.