### PR TITLE
ci: add link checking

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,23 @@
+name: link-checker 
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check Links
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Check links
+      uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332  #v2.4.1
+      with:
+        fail: true
+        lycheeVersion: v0.19.1
+        args: --verbose --no-progress './**/*.md'
+
+

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+#x.com consistently returns a 400 error when run from github actions
+x.com/flatcar


### PR DESCRIPTION
# Add link checking for CI

This adds link checking via `lychee` to ensure that links within the repository are valid (existing and new). This will ensure that data remains up to date as the repository continues to evolve.

## How to use

Open a pull request and you can see links being checked. Additionally you can run this locally if you have [lychee](https://github.com/lycheeverse/lychee) on your system

## Testing done

Ran lychee locally and addressed all existing issues

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.