### PR TITLE
Add CodeQL scanning workflow for Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 3 * * 0' # weekly scan
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
# Add CodeQL scanning workflow for Go

This pull request adds a GitHub Actions workflow to enable CodeQL security scanning for Go code in the `go-omaha` repository. This addresses the CI configuration gap where CodeQL-based checks were enabled but not defined in the repository, causing checks to hang or fail.

The workflow runs on pushes to `main`, pull requests targeting `main`, and also includes a scheduled weekly scan.

This setup is based on the approach from PR #1803 in the main Flatcar repo and is part of the ongoing effort to standardize CI/CD and security across Flatcar projects.

---

## How to use

No manual action required. Once this is merged:
- CodeQL scans will run automatically on every PR and push
- Weekly security scans will run via GitHub Actions

---

## Testing done

- Added the workflow to `.github/workflows/codeql.yml`
- Opened the PR from a forked repo and confirmed the CodeQL job triggers properly
- Verified workflow structure using GitHub Codespaces

---

- [ ] Changelog entry: Not applicable (repo may not use changelogs)
- [x] CI expected to pass after PR is opened
