### PR TITLE
feat(omaha): add multi-manifest support for multi-step updates

### DIFF
--- a/omaha/client/client_test.go
+++ b/omaha/client/client_test.go
@@ -130,8 +130,8 @@ func TestClientWithUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if update.Manifest.Version != "1.1.1" {
-		t.Fatalf("expected version 1.1.1, not %s", update.Manifest.Version)
+	if len(update.Manifests) == 0 || update.Manifests[0].Version != "1.1.1" {
+		t.Fatalf("expected version 1.1.1, got %v", update.Manifests)
 	}
 
 	if len(r.pings) != 1 {

--- a/omaha/client/example_test.go
+++ b/omaha/client/example_test.go
@@ -88,7 +88,7 @@ func Example() {
 	})
 
 	// Restart, new application is now running.
-	c.SetVersion(update.Manifest.Version)
+	c.SetVersion(update.Manifests[0].Version)
 	c.Event(&omaha.EventRequest{
 		Type:   omaha.EventTypeUpdateComplete,
 		Result: omaha.EventResultSuccessReboot,

--- a/omaha/handler.go
+++ b/omaha/handler.go
@@ -123,5 +123,5 @@ func (o *OmahaHandler) checkUpdate(appResp *AppResponse, httpReq *http.Request, 
 
 func fillUpdate(u *UpdateResponse, update *Update, httpReq *http.Request) {
 	u.URLs = update.URLs([]string{"http://" + httpReq.Host})
-	u.Manifest = &update.Manifest
+	u.Manifests = []*Manifest{&update.Manifest}
 }

--- a/omaha/protocol.go
+++ b/omaha/protocol.go
@@ -112,6 +112,9 @@ type AppRequest struct {
 	MachineID    string `xml:"machineid,attr,omitempty"`
 	OEM          string `xml:"oem,attr,omitempty"`
 	OEMVersion   string `xml:"oemversion,attr,omitempty"`
+	
+	// multi-manifest update extension
+	MultiManifestOK bool `xml:"multi_manifest_ok,attr,omitempty"`
 }
 
 func (a *AppRequest) AddUpdateCheck() *UpdateRequest {
@@ -225,9 +228,9 @@ func (a *AppResponse) AddEvent() *EventResponse {
 }
 
 type UpdateResponse struct {
-	URLs     []*URL       `xml:"urls>url" json:",omitempty"`
-	Manifest *Manifest    `xml:"manifest"`
-	Status   UpdateStatus `xml:"status,attr,omitempty"`
+	URLs      []*URL       `xml:"urls>url" json:",omitempty"`
+	Manifests []*Manifest  `xml:"manifest" json:",omitempty"`
+	Status    UpdateStatus `xml:"status,attr,omitempty"`
 }
 
 func (u *UpdateResponse) AddURL(codebase string) *URL {
@@ -237,8 +240,9 @@ func (u *UpdateResponse) AddURL(codebase string) *URL {
 }
 
 func (u *UpdateResponse) AddManifest(version string) *Manifest {
-	u.Manifest = &Manifest{Version: version}
-	return u.Manifest
+	m := &Manifest{Version: version}
+	u.Manifests = append(u.Manifests, m)
+	return m
 }
 
 type PingResponse struct {
@@ -264,6 +268,11 @@ type Manifest struct {
 	Packages []*Package `xml:"packages>package"`
 	Actions  []*Action  `xml:"actions>action"`
 	Version  string     `xml:"version,attr"`
+	
+	// multi-step update extensions
+	IsFloor     bool   `xml:"is_floor,attr,omitempty"`
+	FloorReason string `xml:"floor_reason,attr,omitempty"`
+	IsTarget    bool   `xml:"is_target,attr,omitempty"`
 }
 
 func (m *Manifest) AddPackage() *Package {

--- a/omaha/protocol_test.go
+++ b/omaha/protocol_test.go
@@ -130,7 +130,7 @@ func TestOmahaResponseWithUpdate(t *testing.T) {
 				URLs: []*URL{&URL{
 					CodeBase: "http://kam:8080/static/",
 				}},
-				Manifest: &Manifest{
+				Manifests: []*Manifest{&Manifest{
 					Version: "9999.0.0",
 					Packages: []*Package{&Package{
 						SHA1:     "+LXvjiaPkeYDLHoNKlf9qbJwvnk=",
@@ -144,7 +144,7 @@ func TestOmahaResponseWithUpdate(t *testing.T) {
 						SHA256:         "0VAlQW3RE99SGtSB5R4m08antAHO8XDoBMKDyxQT/Mg=",
 						IsDeltaPayload: true,
 					}},
-				},
+				}},
 			},
 		}},
 	}
@@ -248,4 +248,201 @@ func ExampleNewRequest() {
 	//   <event eventtype="1" eventresult="0"></event>
 	//  </app>
 	// </request>
+}
+
+func TestMultiManifestParsing(t *testing.T) {
+	// Test XML with multiple manifest elements
+	const multiManifestXML = `<?xml version="1.0" encoding="UTF-8"?>
+<response protocol="3.0">
+<daystart elapsed_seconds="0"/>
+<app appid="{e96281a6-d1af-4bde-9a0a-97b76e56dc57}" status="ok">
+<updatecheck status="ok">
+<urls>
+<url codebase="https://update.release.flatcar-linux.net/amd64-usr/"/>
+</urls>
+<manifest version="1.5.0" is_floor="true" floor_reason="Required for partition migration">
+<packages>
+<package name="flatcar_production_update.gz" hash="hash1" size="536373876" required="true"/>
+</packages>
+<actions>
+<action event="postinstall" sha256="sha256_1_5_0"/>
+</actions>
+</manifest>
+<manifest version="2.0.0" is_floor="true" floor_reason="Bootloader update required">
+<packages>
+<package name="flatcar_production_update.gz" hash="hash2" size="538373876" required="true"/>
+</packages>
+<actions>
+<action event="postinstall" sha256="sha256_2_0_0"/>
+</actions>
+</manifest>
+<manifest version="4.0.0" is_target="true">
+<packages>
+<package name="flatcar_production_update.gz" hash="hash3" size="542373876" required="true"/>
+</packages>
+<actions>
+<action event="postinstall" sha256="sha256_4_0_0"/>
+</actions>
+</manifest>
+</updatecheck>
+</app>
+</response>`
+
+	resp, err := ParseResponse("", strings.NewReader(multiManifestXML))
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+
+	uc := resp.Apps[0].UpdateCheck
+	if uc == nil {
+		t.Fatal("UpdateCheck is nil")
+	}
+
+	if len(uc.Manifests) != 3 {
+		t.Fatalf("Manifests count: want 3, got %d", len(uc.Manifests))
+	}
+
+	// Verify floor manifests
+	if !uc.Manifests[0].IsFloor || uc.Manifests[0].Version != "1.5.0" {
+		t.Error("First manifest should be floor version 1.5.0")
+	}
+	if uc.Manifests[0].FloorReason != "Required for partition migration" {
+		t.Errorf("Floor reason: want 'Required for partition migration', got %q", uc.Manifests[0].FloorReason)
+	}
+
+	if !uc.Manifests[1].IsFloor || uc.Manifests[1].Version != "2.0.0" {
+		t.Error("Second manifest should be floor version 2.0.0")
+	}
+
+	// Verify target manifest
+	if !uc.Manifests[2].IsTarget || uc.Manifests[2].Version != "4.0.0" {
+		t.Error("Third manifest should be target version 4.0.0")
+	}
+	if uc.Manifests[2].IsFloor {
+		t.Error("Target manifest should not be marked as floor")
+	}
+}
+
+func TestSingleManifestParsing(t *testing.T) {
+	// Test that single manifest responses still parse correctly
+	const singleManifestXML = `<?xml version="1.0" encoding="UTF-8"?>
+<response protocol="3.0">
+<daystart elapsed_seconds="0"/>
+<app appid="{e96281a6-d1af-4bde-9a0a-97b76e56dc57}" status="ok">
+<updatecheck status="ok">
+<urls>
+<url codebase="https://update.release.flatcar-linux.net/amd64-usr/"/>
+</urls>
+<manifest version="3.0.0">
+<packages>
+<package name="flatcar_production_update.gz" hash="hash3" size="542373876" required="true"/>
+</packages>
+<actions>
+<action event="postinstall" sha256="sha256_3_0_0"/>
+</actions>
+</manifest>
+</updatecheck>
+</app>
+</response>`
+
+	resp, err := ParseResponse("", strings.NewReader(singleManifestXML))
+	if err != nil {
+		t.Fatalf("ParseResponse failed: %v", err)
+	}
+
+	uc := resp.Apps[0].UpdateCheck
+	if uc == nil {
+		t.Fatal("UpdateCheck is nil")
+	}
+
+	if len(uc.Manifests) != 1 {
+		t.Fatalf("Manifests count: want 1, got %d", len(uc.Manifests))
+	}
+
+	if uc.Manifests[0].Version != "3.0.0" {
+		t.Errorf("Manifest version: want '3.0.0', got %q", uc.Manifests[0].Version)
+	}
+}
+
+func TestMultiManifestOKMarshaling(t *testing.T) {
+	req := NewRequest()
+	app := req.AddApp("{e96281a6-d1af-4bde-9a0a-97b76e56dc57}", "1.0.0")
+	app.MultiManifestOK = true
+	app.AddUpdateCheck()
+
+	data, err := xml.Marshal(req)
+	if err != nil {
+		t.Fatalf("xml.Marshal failed: %v", err)
+	}
+
+	// Verify attribute is present
+	if !strings.Contains(string(data), `multi_manifest_ok="true"`) {
+		t.Error("multi_manifest_ok attribute missing in marshaled XML")
+	}
+
+	// Round-trip test
+	parsed, err := ParseRequest("", strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("ParseRequest failed: %v", err)
+	}
+
+	if !parsed.Apps[0].MultiManifestOK {
+		t.Error("MultiManifestOK not preserved in round-trip")
+	}
+}
+
+func TestMultiManifestMarshaling(t *testing.T) {
+	resp := NewResponse()
+	app := resp.AddApp("{e96281a6-d1af-4bde-9a0a-97b76e56dc57}", "ok")
+	uc := app.AddUpdateCheck(UpdateOK)
+	uc.AddURL("https://update.release.flatcar-linux.net/amd64-usr/")
+	
+	// Add multiple manifests
+	m1 := uc.AddManifest("1.5.0")
+	m1.IsFloor = true
+	m1.FloorReason = "Required for partition migration"
+	pkg1 := m1.AddPackage()
+	pkg1.Name = "flatcar_production_update.gz"
+	pkg1.SHA1 = "hash1"
+	pkg1.Size = 536373876
+	pkg1.Required = true
+	
+	m2 := uc.AddManifest("2.0.0")
+	m2.IsFloor = true
+	m2.FloorReason = "Bootloader update required"
+	pkg2 := m2.AddPackage()
+	pkg2.Name = "flatcar_production_update.gz"
+	pkg2.SHA1 = "hash2"
+	pkg2.Size = 538373876
+	pkg2.Required = true
+	
+	m3 := uc.AddManifest("4.0.0")
+	m3.IsTarget = true
+	pkg3 := m3.AddPackage()
+	pkg3.Name = "flatcar_production_update.gz"
+	pkg3.SHA1 = "hash3"
+	pkg3.Size = 542373876
+	pkg3.Required = true
+	
+	data, err := xml.Marshal(resp)
+	if err != nil {
+		t.Fatalf("xml.Marshal failed: %v", err)
+	}
+	
+	// Verify multiple manifest elements are present
+	xmlStr := string(data)
+	if strings.Count(xmlStr, "<manifest") != 3 {
+		t.Errorf("Expected 3 manifest elements, got: %s", xmlStr)
+	}
+	
+	// Verify floor attributes
+	if !strings.Contains(xmlStr, `is_floor="true"`) {
+		t.Error("is_floor attribute missing")
+	}
+	if !strings.Contains(xmlStr, `floor_reason="Required for partition migration"`) {
+		t.Error("floor_reason attribute missing")
+	}
+	if !strings.Contains(xmlStr, `is_target="true"`) {
+		t.Error("is_target attribute missing")
+	}
 }

--- a/omaha/trivial_server_test.go
+++ b/omaha/trivial_server_test.go
@@ -118,13 +118,14 @@ func TestTrivialServer(t *testing.T) {
 		resp.Apps[0].UpdateCheck == nil ||
 		resp.Apps[0].UpdateCheck.Status != UpdateOK ||
 		len(resp.Apps[0].UpdateCheck.URLs) != 1 ||
-		resp.Apps[0].UpdateCheck.Manifest == nil ||
-		len(resp.Apps[0].UpdateCheck.Manifest.Packages) != 1 {
+		len(resp.Apps[0].UpdateCheck.Manifests) != 1 ||
+		resp.Apps[0].UpdateCheck.Manifests[0] == nil ||
+		len(resp.Apps[0].UpdateCheck.Manifests[0].Packages) != 1 {
 		t.Fatalf("unexpected response: %#v", resp)
 	}
 
 	pkgres, err := http.Get(resp.Apps[0].UpdateCheck.URLs[0].CodeBase +
-		resp.Apps[0].UpdateCheck.Manifest.Packages[0].Name)
+		resp.Apps[0].UpdateCheck.Manifests[0].Packages[0].Name)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Add MultiPackageOK field to AppRequest to indicate client capability
- Replace single Manifest field with Manifests array in UpdateResponse
- Add floor metadata fields (IsFloor, FloorReason, IsTarget) to Manifest
- Maintain backward compatibility by handling both single and multi-manifest cases
- Update tests to use new Manifests array structure

This enables the Omaha protocol to support multi-step syncs where clients must install intermediate 'floor' versions together with the target version.

Needed for https://github.com/flatcar/nebraska/pull/1195
